### PR TITLE
webkitgtk3: the gst stuff should be 1.0 and not the older 0.x. Removing ...

### DIFF
--- a/libs/webkitgtk3/BUILD
+++ b/libs/webkitgtk3/BUILD
@@ -1,6 +1,5 @@
 # breaks without webgl for now
 OPTS+=" --enable-x11-target           \
-        --enable-xslt                 \
         --enable-optimizations        \
         --enable-introspection        \
         --disable-glibtest            \

--- a/libs/webkitgtk3/DEPENDS
+++ b/libs/webkitgtk3/DEPENDS
@@ -13,17 +13,13 @@ depends  libsoup
 depends  libsecret
 depends  harfbuzz
 depends  enchant
-depends  gst-plugins-base
-depends  gst-plugins-good
+depends  gst-plugins-base-1.0
+depends  gst-plugins-good-1.0
 depends  ruby
+depends  geoclue2
 
 # workaround for make_names.pl
 depends Switch
-
-optional_depends "geoclue2" \
-                 "--enable-geolocation" \
-                 "--disable-geolocation" \
-                 "for geolocation support"
 
 optional_depends "librsvg" \
                  "--enable-svg --enable-svg-fonts" \


### PR DESCRIPTION
...another invalid switch in the

BUILD. twocowchip discovered this version has a hard depends on geoclue2. I verified that by a lin
without it, it fails with;

install: cannot stat 'Programs/GtkLauncher': No such file or directory
