### PR TITLE
webkitgtk3: Adjustment to the BUILD. The aim here is utilizing the webki...

### DIFF
--- a/libs/webkitgtk3/BUILD
+++ b/libs/webkitgtk3/BUILD
@@ -3,7 +3,6 @@ OPTS+=" --enable-x11-target           \
         --enable-optimizations        \
         --enable-introspection        \
         --disable-glibtest            \
-        --with-gtk=3.0                \
         --enable-video                \
         --enable-webgl                \
         --disable-gtk-doc-html"      &&
@@ -13,20 +12,28 @@ if ! module_installed gtk-doc ; then
   sed -i '/gtkdoc --rebase/s:^:# :' GNUmakefile.in
 fi &&
 
-#stolen from blfs, avoid race condition in build with multiple makes
-default_config &&
-error_count=0 &&
-until default_make
-do
-  if (( $((error_count++)) > 4 )) ; then
-    echo Too Many Errors &&
-    break
-  fi
-done &&
-unset error_count &&
-
+# First we build the gtk3 version
+mkdir build-3 &&
+cp -a Documentation build-3 &&
+cd build-3
+OPTS+=" --with-gtk=3.0" &&
+../configure --prefix=/usr $OPTS &&
+default_make &&
 install 'Programs/GtkLauncher' '/usr/bin/Gtk3Launcher' &&
 
+cd ../ &&
+# Now if gtk+-2 is install we build for it
+if module_installed gtk+-2 ; then
+mkdir build-2 &&
+cp -a Documentation build-2 &&
+cd build-2
+OPTS+=" --with-gtk=2.0 --disable-webkit2" &&
+../configure --prefix=/usr $OPTS &&
+default_make &&
+install 'Programs/GtkLauncher' '/usr/bin/Gtk2Launcher'
+fi &&
+
+cd ../ &&
 # symlink plugin folder to a location webkit looks for it
 if [ ! -e "/usr/lib/browser-plugins" ]; then
    ln -sf /usr/lib/lunar/plugins /usr/lib/browser-plugins


### PR DESCRIPTION
...t2 portion of

webkitgtk3 and move those modules dependent on webkit to this one. This will allow us
to remove the webkit module. This method is borrowed from the lfs folks. If you want to see the diff between the way the BUILD was and this one, visit http://lunar-linux.org/~stumbles/ and diff the two webkitgtk3 files.
