### PR TITLE
libgweather:dependent on gtk-doc

### DIFF
--- a/libs/libgweather/DEPENDS
+++ b/libs/libgweather/DEPENDS
@@ -4,13 +4,9 @@ depends libsoup
 depends geocode-glib
 depends intltool
 depends meson
+depends gtk-doc
 
 optional_depends vala \
                  "-Denable-vala=true" \
                  "-Denable_vala=false" \
                  "for object introspection"
-
-optional_depends gtk-doc \
-                 "-Dgtk_doc=true" \
-                 "-Dgtk_doc-false" \
-                 "for building documentation"


### PR DESCRIPTION
Without gtk-doc can not be compiled.