### PR TITLE
nautilus: fix dependencies

### DIFF
--- a/core/nautilus/DEPENDS
+++ b/core/nautilus/DEPENDS
@@ -1,14 +1,16 @@
 depends dconf
 depends gnome-desktop
 depends libexif
-depends exempi
 depends gvfs
-depends gexiv2
 depends desktop-file-utils
 depends gnome-icon-theme
-#depends gnome-autoar
+depends gnome-autoar
 depends libnotify
 depends tracker
 depends meson
 
-#depends nautilus-sendto
+optional_depends "gexiv2" \
+                 " -Dextensions=true" \
+                 " -Dextensions=false" \
+                 "Build extension support on nautilus"
+                 


### PR DESCRIPTION
gnome-autoar is a hard dependency
gexiv2 is an optional dependency