### PR TITLE
gnome-power-manager: disable docbook2man support form man pages (it's…

### DIFF
--- a/core/gnome-power-manager/BUILD
+++ b/core/gnome-power-manager/BUILD
@@ -1,3 +1,5 @@
-OPTS+=" --prefix /usr -Denable-tests=false"
+OPTS+=" --prefix /usr \
+        -D docbook2man=false \
+        -D enable-tests=false"
 
 default_meson_build


### PR DESCRIPTION
… broken).