### PR TITLE
clutter: if cogl has been built with wayland, then enable egl backend…

### DIFF
--- a/libs/clutter/BUILD
+++ b/libs/clutter/BUILD
@@ -1,8 +1,8 @@
-OPTS+=" --enable-debug=no    \
-        --enable-x11-backend \
-        --enable-gdk-backend \
-        --disable-egl-backend"
+OPTS+=" --enable-debug=no --enable-x11-backend --enable-gdk-backend"
 
+if in_depends cogl wayland; then
+  OPTS+=" --enable-egl-backend"
+fi &&
 if module_installed libinput; then
   OPTS+=" --enable-evdev-input"
 fi &&


### PR DESCRIPTION
… too