### PR TITLE
gnome-system-monitor: version bump

### DIFF
--- a/apps/gnome-system-monitor/BUILD
+++ b/apps/gnome-system-monitor/BUILD
@@ -1,0 +1,1 @@
+default_meson_build

--- a/apps/gnome-system-monitor/DEPENDS
+++ b/apps/gnome-system-monitor/DEPENDS
@@ -1,0 +1,3 @@
+depends  gnome-icon-theme
+depends  gtkmm
+depends  libgtop

--- a/apps/gnome-system-monitor/DETAILS
+++ b/apps/gnome-system-monitor/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=gnome-system-monitor
+         VERSION=3.32.1
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
+      SOURCE_VFY=sha256:48c131335091bd927862f40ef56400f997981df2acfc82abea662bf91a1ea4f1
+        WEB_SITE=http://www.gnome.org
+         ENTERED=20050316
+         UPDATED=20190417
+           SHORT="process viewer and system resource monitor for GNOME"
+
+cat << EOF
+gnome-system-monitor allows you to graphically view and manipulate the
+running processes on your system. It also provides an overview of
+available resources such as CPU and memory.
+EOF


### PR DESCRIPTION
move gnome-system-monitor from gnome/desktop/ to gnome3/apps/