### PR TITLE
gedit: changed to default_meson_build

### DIFF
--- a/apps/gedit/BUILD
+++ b/apps/gedit/BUILD
@@ -1,6 +1,1 @@
-OPTS+=" --enable-python \
-        --enable-vala \
-        --disable-updater \
-        --disable-schemas-compile"
-
-default_build
+default_meson_build


### PR DESCRIPTION
The configure was exiting with this message:
+ running "default_build"
+ running "default_gnu_build"
+ running "default_config"
Missing configure and/or Makefile!
Creating /var/log/lunar/compile/gedit-3.32.2.xz 
! Problem detected during BUILD
