### PR TITLE
mutter: disable profiler support

### DIFF
--- a/core/mutter/BUILD
+++ b/core/mutter/BUILD
@@ -1,3 +1,3 @@
 #remote desktop needs pipewire that is not yet included as a package
-OPTS+=" -Dremote_desktop=false"
+OPTS+=" -Dremote_desktop=false -Dprofiler=false"
 default_meson_build


### PR DESCRIPTION
currently gnome sysprof does not supported by lunar