### PR TITLE
polari: add gspell (runtime) dependency, add checks in PRE_BUILD

### DIFF
--- a/apps/polari/DEPENDS
+++ b/apps/polari/DEPENDS
@@ -1,2 +1,3 @@
 depends gjs
 depends telepathy-glib
+depends gspell

--- a/apps/polari/PRE_BUILD
+++ b/apps/polari/PRE_BUILD
@@ -1,0 +1,15 @@
+default_pre_build
+if module_installed telepathy-glib; then
+  if ! in_depends telepathy-glib gobject-introspection; then
+    error_message "Polari needs telepathy-glib with introspection enabled"
+    error_message "Relin telepathy-glib and select gobject-introspection support"
+    exit
+  fi
+fi
+if module_installed gspell; then
+  if ! in_depends gspell gobject-introspection; then
+    error_message "Polari needs gspell with introspection enabled"
+    error_message "Relin gspell and select gobject-introspection support"
+    exit
+  fi
+fi


### PR DESCRIPTION
polari needs gspell and telepathy-glib as a bare minimum for compilation.
but its runtime it needs the previous modules to have gobject-introspection support.
PRE_BUILD added that checks if gspell and telepathy-glib are installed and if yes if they
have been compiled with gobject-introspection enabled, otherwise it prevents polari's
compilation