### PR TITLE
mutter: version bump

### DIFF
--- a/core/mutter/BUILD
+++ b/core/mutter/BUILD
@@ -1,5 +1,5 @@
 #remote desktop needs pipewire that is not yet included as a package
-OPTS+=" -Dremote_desktop=false -Dprofiler=false -Dgles2=false -Dnative_backend=false"
+OPTS+=" -Dprofiler=false -Dgles2=true -Dnative_backend=true"
 
 if in_depends $MODULE wayland-protocols; then
   if ! in_depends $MODULE mesa-lib; then

--- a/core/mutter/DEPENDS
+++ b/core/mutter/DEPENDS
@@ -22,3 +22,9 @@ optional_depends mesa-lib \
                  "-Degl=false -Dglx=false" \
                  "Enable EGL support" \
                  y
+
+optional_depends pipewire \
+                 "-Dremote_desktop=true" \
+                 "-Dremote_desktop=false" \
+                 "Enable remote desktop support" \
+                 y

--- a/core/mutter/DETAILS
+++ b/core/mutter/DETAILS
@@ -1,11 +1,11 @@
           MODULE=mutter
-         VERSION=3.34.3
+         VERSION=3.34.4
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION::4}
-      SOURCE_VFY=sha256:cdf57ddd0bc35db952b732b77c796760e65d1ce2f7df31273e5c8d4759ed4a89
+      SOURCE_VFY=sha256:0134513515f605dd0858154d0b54d2e23c5779d52590533e266d407251e20ba2
         WEB_SITE=http://www.gnome.org
          ENTERED=20131020
-         UPDATED=20200105
+         UPDATED=20200216
            SHORT="A window manager for GNOME"
 
 cat << EOF


### PR DESCRIPTION
reenable support for native backend, which is needed to start a wayland
gnome-shell from command line