### PR TITLE
file-roller: version bump and moved under gnome3

### DIFF
--- a/apps/file-roller/BUILD
+++ b/apps/file-roller/BUILD
@@ -1,0 +1,1 @@
+default_meson_build

--- a/apps/file-roller/DEPENDS
+++ b/apps/file-roller/DEPENDS
@@ -1,0 +1,6 @@
+depends  gtk+-3
+
+optional_depends  "nautilus"                    \
+                  "-Dnautilus-actions=true"   \
+                  "-Dnautilus-actions=false"  \
+                  "for context menu support in Nautilus"

--- a/apps/file-roller/DETAILS
+++ b/apps/file-roller/DETAILS
@@ -1,0 +1,19 @@
+          MODULE=file-roller
+           MAJOR=3.32
+         VERSION=$MAJOR.4
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=$GNOME_URL/sources/$MODULE/$MAJOR
+      SOURCE_VFY=sha256:1b3b2cbfcb444e0d150bfd063add9d5181c8ab24f0593e5a8894399297214017
+        WEB_SITE=http://www.gnome.org
+         ENTERED=20021013
+         UPDATED=20200216
+           SHORT="An archive manager for the GNOME environment"
+
+cat << EOF
+File Roller is an archive manager for the GNOME environment.
+Archive manager means that you can:
+o Create and modify archives.
+o View the content of an archive.
+o View a file contained in the archive.
+o Extract files from the archive.
+EOF


### PR DESCRIPTION
old file-roller entry under gnome/desktop needs to be removed