### PR TITLE
gnome-desktop:depends libxml2

### DIFF
--- a/core/gnome-desktop/DEPENDS
+++ b/core/gnome-desktop/DEPENDS
@@ -6,6 +6,7 @@ depends xkeyboard-config
 depends libseccomp
 depends itstool
 depends meson
+depends libxml2
 
 optional_depends gtk-doc \
                  "-Dgtk-doc=true" \


### PR DESCRIPTION
gnome-desktop:depends libxml2