### PR TITLE
sysprof: initial import as a gnome package

### DIFF
--- a/apps/sysprof/DEPENDS
+++ b/apps/sysprof/DEPENDS
@@ -1,0 +1,14 @@
+#pango is needed in case user select nogtk build
+depends pango
+
+optional_depends "libdazzle" \
+                 "-Denable_gtk=true" \
+                 "-Denable_gtk=false" \
+                 "enable gtk UI support" \
+                 "y"
+
+optional_depends "libunwind" \
+                 "-Dlibunwind=true" \
+                 "-Dlibunwind=false" \
+                 "enable support for libunwind" \
+                 "n"

--- a/apps/sysprof/DETAILS
+++ b/apps/sysprof/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=sysprof
+         VERSION=3.36.0
+          SOURCE=${MODULE}-${VERSION}.tar.xz
+      SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
+      SOURCE_VFY=sha256:8670db4dacf7b219d30c575c465b17c8ed6724dbade347f2cde9548bff039108
+        WEB_SITE="http://www.daimi.au.dk/~sandmann/sysprof/"
+         ENTERED=20200319
+         UPDATED=20200319
+           SHORT="system profiler (sysprof) for gnome"
+            TYPE=meson
+
+cat << EOF
+Profiling tool that helps in finding the functions in which a program
+uses most of its time
+EOF


### PR DESCRIPTION
currently sysprof under other/crater/ which will have to be removed and add the newest under
gnome3/apps/