### PR TITLE
gobject-introspection: update DEPENDS to python3

### DIFF
--- a/core/gobject-introspection/DEPENDS
+++ b/core/gobject-introspection/DEPENDS
@@ -10,4 +10,4 @@ optional_depends cairo \
                  "for cairo graphics support${PROBLEM_COLOR} While this defaults to yes, you should say no on a clean install, else you will have troubles${DEFAULT_COLOR}" \
                  "y"
 
-optional_depends python2 "" "" "for Python support" "n"
+optional_depends python "" "" "for Python support" "n"


### PR DESCRIPTION
optional_depends was using python2, updated to use python3 (default)