### PR TITLE
gobject-introspection: even better update to DEPENDS

### DIFF
--- a/core/gobject-introspection/DEPENDS
+++ b/core/gobject-introspection/DEPENDS
@@ -10,4 +10,4 @@ optional_depends cairo \
                  "for cairo graphics support${PROBLEM_COLOR} While this defaults to yes, you should say no on a clean install, else you will have troubles${DEFAULT_COLOR}" \
                  "y"
 
-optional_depends python2 "" "" "for Python support" "n"
+optional_depends python "" "" "for Python support" "n"

--- a/core/gobject-introspection/DEPENDS
+++ b/core/gobject-introspection/DEPENDS
@@ -9,5 +9,3 @@ optional_depends cairo \
                  "-Dcairo=disabled" \
                  "for cairo graphics support${PROBLEM_COLOR} While this defaults to yes, you should say no on a clean install, else you will have troubles${DEFAULT_COLOR}" \
                  "y"
-
-optional_depends python "" "" "for Python support" "n"


### PR DESCRIPTION
after discussing the previous PR in more detail (see the now-closed https://github.com/lunar-linux/moonbase-gnome3/pull/229}, it's actually better to get rid of the optional_depends for python entirely.