### PR TITLE
gnome-menus: remove unneeded dependency

### DIFF
--- a/core/gnome-menus/DEPENDS
+++ b/core/gnome-menus/DEPENDS
@@ -1,4 +1,3 @@
-depends python2
 depends intltool
 
 optional_depends gobject-introspection \


### PR DESCRIPTION
gnome-menus doesn't explicitly require python at all. Removed from DEPENDS.