### PR TITLE
Alacarte: version bump

### DIFF
--- a/core/alacarte/DETAILS
+++ b/core/alacarte/DETAILS
@@ -1,11 +1,11 @@
           MODULE=alacarte
-         VERSION=3.11.91
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/GNOME/alacarte/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:ea2810b917ca6f4fc8694683b893d008bdb2fb7cd5ce503917a4828c3f282605
+         VERSION=3.36.0
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
+      SOURCE_VFY=5c1e09a8926ac77a049b199c97ac459f98a65816041feb392c839a91edc8e75d
         WEB_SITE=http://www.gnome.org
          ENTERED=20160218
-         UPDATED=20181006
+         UPDATED=20200422
            SHORT="Menu editor for Gnome"
 
 cat << EOF

--- a/core/gnome-menus/DEPENDS
+++ b/core/gnome-menus/DEPENDS
@@ -1,4 +1,3 @@
-depends python2
 depends intltool
 
 optional_depends gobject-introspection \

--- a/libs/gdk-pixbuf/DEPENDS
+++ b/libs/gdk-pixbuf/DEPENDS
@@ -2,6 +2,7 @@ depends glib-2
 depends shared-mime-info
 depends tiff
 depends meson
+depends docbook-xsl
 
 optional_depends %JPEG \
                  "-Djpeg=true" \
@@ -35,7 +36,7 @@ optional_depends libxml2 \
 
 optional_depends gtk-doc \
                  "-Ddocs=true" \
-                 "-Ddecs=false" \
+                 "-Ddocs=false" \
                  "for building documentation" \
                  "n"
 


### PR DESCRIPTION
Version bump, changed download location to GNOME instead of github, updated sha256.