### PR TITLE
alacarte pt2 (x3): changed almost everything

### DIFF
--- a/core/alacarte/BUILD
+++ b/core/alacarte/BUILD
@@ -1,0 +1,1 @@
+default_build

--- a/core/alacarte/BUILD
+++ b/core/alacarte/BUILD
@@ -1,5 +1,0 @@
-PYTHON=/usr/bin/python2
-
-default_build &&
-
-python2 -m compileall /usr/lib/python2.7/site-packages/Alacarte/

--- a/core/alacarte/DEPENDS
+++ b/core/alacarte/DEPENDS
@@ -1,5 +1,7 @@
-depends gnome-common
 depends gnome-menus
 depends hicolor-icon-theme
-depends libxslt
-depends docbook-xsl
+
+optional_depends docbook2X \
+    "--enable-documentation" \
+    "--disable-documentation" \
+    "to install documentation"

--- a/core/alacarte/DEPENDS
+++ b/core/alacarte/DEPENDS
@@ -1,3 +1,4 @@
+depends python-pygobject
 depends gnome-menus
 depends hicolor-icon-theme
 

--- a/core/alacarte/DETAILS
+++ b/core/alacarte/DETAILS
@@ -1,11 +1,11 @@
           MODULE=alacarte
-         VERSION=3.11.91
-          SOURCE=$MODULE-$VERSION.tar.gz
- SOURCE_URL_FULL=https://github.com/GNOME/alacarte/archive/$VERSION.tar.gz
-      SOURCE_VFY=sha256:ea2810b917ca6f4fc8694683b893d008bdb2fb7cd5ce503917a4828c3f282605
+         VERSION=3.36.0
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
+      SOURCE_VFY=5c1e09a8926ac77a049b199c97ac459f98a65816041feb392c839a91edc8e75d
         WEB_SITE=http://www.gnome.org
          ENTERED=20160218
-         UPDATED=20181006
+         UPDATED=20200422
            SHORT="Menu editor for Gnome"
 
 cat << EOF

--- a/core/alacarte/PRE_BUILD
+++ b/core/alacarte/PRE_BUILD
@@ -1,3 +1,0 @@
-default_pre_build &&
-
-./autogen.sh


### PR DESCRIPTION
BUILD: Removed the forced use of python2.
DEPENDS: Does not require on gnome-common, but does require python-pygobject. Removed libxslt and docbook-xsl, which are only required if documentation is installed (optional). Added docbook2X as an optional_depends.
DETAILS: Version bump, changed to GNOME download source, updated sha256sum.
PRE_BUILD: Only ran autogen.sh, unnecessary for compilation. Removed it entirely.