### PR TITLE
GDL: GNOME Docking Library

### DIFF
--- a/libs/gdl/BUILD
+++ b/libs/gdl/BUILD
@@ -1,0 +1,1 @@
+default_build

--- a/libs/gdl/DEPENDS
+++ b/libs/gdl/DEPENDS
@@ -1,0 +1,7 @@
+depends gnome-common
+depends gtk-doc
+
+optional_depends gobject-introspection \
+    "--enable-introspection=yes" \
+    "--enable-introspection=no" \
+    "enable introspection"

--- a/libs/gdl/DETAILS
+++ b/libs/gdl/DETAILS
@@ -1,0 +1,13 @@
+          MODULE=gdl
+         VERSION=3.34.0
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=https://download.gnome.org/sources/$MODULE/${VERSION%.*}
+      SOURCE_VFY=858b30f0cdce4c4cb3e8365a7d54ce57c388beff38ea583be5449bc78dda8d02
+        WEB_SITE=https://gitlab.gnome.org/GNOME/gdl
+         ENTERED=20190818
+         UPDATED=20200408
+           SHORT="Provides docking features for gtk+."
+
+cat << EOF
+GNOME Docking Library - Provides docking features for gtk+.
+EOF


### PR DESCRIPTION
GNOME Docking Library - Provides docking features for gtk+.

Needed by inkscape >= 1.0 and darktable >= 3.0.