### PR TITLE
evolution: fix missing optional_depends

### DIFF
--- a/core/evolution/DEPENDS
+++ b/core/evolution/DEPENDS
@@ -3,6 +3,11 @@ depends hicolor-icon-theme
 
 optional_depends libnotify "" "" "for libnotify popups"
 
+optional_depends libytnef \
+                "-DENABLE_YTNEF=ON" \
+                "-DENABLE_YTNEF=OFF" \
+                "for winmail.dat support"
+
 optional_depends libcanberra \
                  "-DENABLE_CANBERRA=ON" \
                  "-DENABLE_CANBERRA=OFF" \


### PR DESCRIPTION
Evolution has libytnef support enabled by default, and will fail to compile without it.

I've added an optional_depends to either install or disable libytnef.