### PR TITLE
gjs - version bump, mozjs dep

### DIFF
--- a/core/gjs/DEPENDS
+++ b/core/gjs/DEPENDS
@@ -1,3 +1,3 @@
 depends gtk+-3
-depends mozjs
+depends mozjs78
 depends gobject-introspection

--- a/core/gjs/DETAILS
+++ b/core/gjs/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:8d4240455eff642c8bf6d9805077e33e0a60cb2ea13f77a55f7f30c29668344c
         WEB_SITE=http://live.gnome.org/Gjs
          ENTERED=20130210
-         UPDATED=20201010
+         UPDATED=20201020
            SHORT="Javascript bindings for GNOME"
             TYPE=meson
 


### PR DESCRIPTION
gjs now requires mozjs78 - which I've made a separate PR for.