### PR TITLE
gthumb - new version

### DIFF
--- a/apps/gthumb/BUILD
+++ b/apps/gthumb/BUILD
@@ -1,0 +1,1 @@
+default_meson_build

--- a/apps/gthumb/DEPENDS
+++ b/apps/gthumb/DEPENDS
@@ -1,0 +1,71 @@
+depends gtk+-3
+depends gsettings-desktop-schemas
+depends libpng
+depends %JPEG
+
+optional_depends  "exiv2" \
+    "-Dexiv2=true" \
+    "-Dexiv2=false" \
+    "Use exiv2 to read and write metadata" \
+    "y"
+
+optional_depends  "clutter" \
+    "-Dclutter=true" \
+    "-Dclutter=false" \
+    "Use clutter to make animated slideshows"
+
+optional_depends  "gstreamer" \
+    "-Dgstreamer=true"  \
+    "-Dgstreamer=false" \
+    "Use gstreamer to play multimedia files" \
+    "y"
+
+optional_depends  "lcms2" \
+    "-Dlcms2=true" \
+    "-Dlcms2=false" \
+    "Use lcms2 to get color management support" \
+    "y"
+
+optional_depends  "colord-gtk" \
+    "-Dcolord=true" \
+    "-Dcolord=false" \
+    "Use colord to read the monitor color profile"
+
+optional_depends  "tiff" \
+    "-Dlibtiff=true" \
+    "-Dlibtiff=false" \
+    "Use libtiff to load Tiff images" \
+    "y"
+
+optional_depends  "libwebp" \
+    "-Dlibwebp=true" \
+    "-Dlibwebp=false" \
+    "Use libwebp to load WebP images" \
+    "y"
+
+optional_depends  "libopenraw" \
+    "-Dlibraw=true" \
+    "-Dlibraw=false" \
+    "Use libopenraw to load RAW images" \
+    "y"
+
+optional_depends  "librsvg" \
+    "-Dlibrsvg=true" \
+    "-Dlibrsvg=false" \
+    "Use librsvg to load SVG images" \
+    "y"
+
+optional_depends  "libsecret" \
+    "-Dlibsecret=true" \
+    "-Dlibsecret=false" \
+    "Use libsecret to save web service account data"
+
+optional_depends  "webkit2gtk3" \
+    "-Dwebservices=true" \
+    "-Dwebservices=false" \
+    "Compile extensions that import/export images from web services"
+
+optional_depends  "brasero" \
+    "-Dlibbrasero=true" \
+    "-Dlibbrasero=false" \
+    "Use libbrasero to save images and metadata to discs"

--- a/apps/gthumb/DETAILS
+++ b/apps/gthumb/DETAILS
@@ -1,0 +1,41 @@
+          MODULE=gthumb
+         VERSION=3.11.1
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=$GNOME_URL/sources/$MODULE/${VERSION%.*}
+      SOURCE_VFY=7ecc1fcc7fc6f09b509046df109fce257d0c72cf0904abad90f6214b8d99ceeb
+        WEB_SITE=http://gthumb.sourceforge.net
+         ENTERED=20021002
+         UPDATED=20201213
+           SHORT="Image browser and viewer for the GNOME Desktop"
+
+cat << EOF
+ Image browser and viewer for the GNOME Desktop.
+
+    * Browse your hard disk showing you thumbnails of image files.
+    * Thumbnails are saved in the same database used by Nautilus so you don't
+          waste disk space.
+    * Automatically update the content of a folder.
+    * Copy, move, delete images and folders.
+    * Bookmarks of folders and catalogs.
+    * View single images (including GIF animations). Supported image types are:
+          BMP, JPEG, GIF, PNG, TIFF, ICO, XPM.
+    * View EXIF data attached to JPEG images.
+    * View in fullscreen mode.
+    * View images rotated, flipped, in black and white.
+    * Add comments to images.
+    * Organize images in catalogs, catalogs in libraries.
+    * Print images and comments.
+    * Search for images on you hard disk and save the result as a catalog.
+          Search criteria remain attached to the catalog so you can update it
+          when you want.
+    * Slideshows.
+    * Set an image as Desktop background.
+    * Create index image.
+    * Rename images in series.
+    * JPEG lossless transformations.
+    * Maintenance tools: remove old/all comments; backup and restore comments;
+          remove old/all thumbnails.
+    * Fully documented.
+    * Image viewer component. Differences with the EOG component: display GIF
+          animations, print the image and its comment.
+EOF


### PR DESCRIPTION
Gthumb is a feature rich image viewer that uses GTK3 and integrates well with the GNOME desktop.
- Version 3.11.1
- There is an old 2.14 in _moonbase-gnome,_ last updated in 2012.