### PR TITLE
libdbusmenu-gtk3

### DIFF
--- a/libs/libdbusmenu-gtk3/BUILD
+++ b/libs/libdbusmenu-gtk3/BUILD
@@ -1,0 +1,6 @@
+export HAVE_VALGRIND_TRUE='#'
+export HAVE_VALGRIND_FALSE=''
+export CFLAGS=" -Wno-error"
+OPTS=" --disable-dumper --disable-tests --disable-static --with-gtk=3 --enable-gtk-doc-html=no"
+
+default_cvs_build

--- a/libs/libdbusmenu-gtk3/DEPENDS
+++ b/libs/libdbusmenu-gtk3/DEPENDS
@@ -1,0 +1,9 @@
+depends dbus-glib
+depends gnome-common
+depends gobject-introspection
+depends gtk+-3
+
+optional_depends vala \
+"" \
+"--disable-vala" \
+"enable vala support?" 

--- a/libs/libdbusmenu-gtk3/DETAILS
+++ b/libs/libdbusmenu-gtk3/DETAILS
@@ -1,0 +1,14 @@
+          MODULE=libdbusmenu-gtk3
+         VERSION=16.04.1+18.10.20180917
+          SOURCE=libdbusmenu_${VERSION}.orig.tar.gz
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
+ SOURCE_URL=https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libdbusmenu/${VERSION}-0ubuntu6/
+SOURCE_VFY=sha256:9be5dc0f2657a9eb76b02d2cdfafa4490652c70bcdfafba5574c505afd2bbe79
+        WEB_SITE=https://launchpad.net/libdbusmenu
+         ENTERED=20201123
+         UPDATED=20201123
+           SHORT="Dbus menu passing library for gtk3"
+
+cat << EOF
+ libdbusmenu passes a menu structure across DBus so that a program can create a menu simply without worrying about how it is displayed on the other side of the bus.
+EOF

--- a/libs/libdbusmenu-gtk3/PRE_BUILD
+++ b/libs/libdbusmenu-gtk3/PRE_BUILD
@@ -1,0 +1,2 @@
+default_pre_build &&
+tar xf $SOURCE_CACHE/libdbusmenu_${VERSION}.orig.tar.gz -C $SOURCE_DIRECTORY


### PR DESCRIPTION
Dbus menu passing library for gtk3. Used as an optional dep in a couple programs, including xapps and the new xfce4-panel-4.16 (coming soon!)

*Note: the PRE_BUILD file is necessary because the tar.gz doesn't have it's own containing directory, so one needs to be provided. -1: 