### PR TITLE
gcr - fix depends

### DIFF
--- a/core/gcr/DEPENDS
+++ b/core/gcr/DEPENDS
@@ -7,6 +7,6 @@ depends gnupg
 depends meson
 
 optional_depends gtk-doc \
-   " " \
+   "" \
    "-Dgtk_doc=false" \
    "for documentation"

--- a/core/gcr/DEPENDS
+++ b/core/gcr/DEPENDS
@@ -5,3 +5,8 @@ depends hicolor-icon-theme
 depends desktop-file-utils
 depends gnupg
 depends meson
+
+optional_depends gtk-doc \
+   " " \
+   "-Dgtk_doc=false" \
+   "for documentation"


### PR DESCRIPTION
gcr defaults to _-Dgtk_doc=true_ and will fail to build unless gtk-doc is already installed.
I've added an optional_depends to fix this.