### PR TITLE
webkit2gtk3 - version bump, other fixes

### DIFF
--- a/libs/webkit2gtk3/BUILD
+++ b/libs/webkit2gtk3/BUILD
@@ -1,26 +1,17 @@
-OPTS+=" -DPORT=GTK \
-        -DUSE_WOFF2=OFF \
-        -DCMAKE_SKIP_RPATH=ON \
-        -DENABLE_WEBKIT_LEGACY=OFF \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DLIB_INSTALL_DIR=/usr/lib"
+OPTS+="-DPORT=GTK \
+   -DUSE_WOFF2=OFF \
+   -DCMAKE_SKIP_RPATH=ON \
+   -DENABLE_WEBKIT_LEGACY=OFF \
+   -DCMAKE_INSTALL_PREFIX=/usr \
+   -DUSE_SYSTEM_MALLOC=ON \
+   -DLIB_INSTALL_DIR=/usr/lib \
+   -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3"
 
 if [[ $MINIBROWSER == "y" ]]; then
   OPTS+=" -DENABLE_MINIBROWSER=ON"
 fi
 
-if [[ $WPEBACKEND == "y" ]]; then
-  OPTS+=" -DUSE_WPE_RENDERER=ON"
-else
-  OPTS+=" -DUSE_WPE_RENDERER=OFF"
-fi
-
-#default_cmake_build &&
-cmake $OPTS -G Ninja . &&
-ninja -j1 &&
-
-prepare_install &&
-ninja -j1 install &&
+default_cmake_build &&
 
 # symlink plugin folder to a location webkit looks for it
 if [ ! -e "/usr/lib/browser-plugins" ]; then

--- a/libs/webkit2gtk3/CONFIGURE
+++ b/libs/webkit2gtk3/CONFIGURE
@@ -1,2 +1,1 @@
 mquery MINIBROWSER "Build webkit's internal minibrowser?" n
-mquery WPEBACKEND  "Build wpe renderer (if yes enable wayland support too)?" y

--- a/libs/webkit2gtk3/DEPENDS
+++ b/libs/webkit2gtk3/DEPENDS
@@ -5,27 +5,18 @@ depends %JPEG
 depends libpng
 depends libwebp
 depends libmanette
-depends mesa-lib
 depends icu4c
 depends enchant
 depends libXt
-depends libxslt
-depends harfbuzz
-depends freetype2
 depends openjpeg-2
 depends gtk+-3
 depends gperf
-depends sqlite
 depends libsoup
 depends libsecret
 depends bubblewrap
 depends xdg-dbus-proxy
 depends libseccomp
-depends zlib
 
-if [ "`get_module_config WPEBACKEND`" = "y" ]; then
-   depends wpebackend-fdo
-fi
 
 optional_depends libnotify \
                  "-DUSE_LIBNOTIFY=ON" \
@@ -42,6 +33,11 @@ optional_depends hyphen \
                  "-DUSE_LIBHYPHEN=OFF" \
                  "for hyphenation and justification support"
 
+optional_depends wpebackend-fdo \
+                 "-DUSE_WPE_RENDERER=ON" \
+                 "-DUSE_WPE_RENDERER=OFF" \
+                 "for wpe renderer - if yes enable wayland support (next)" y
+   
 optional_depends wayland-protocols \
                  "-DENABLE_WAYLAND_TARGET=ON" \
                  "-DENABLE_WAYLAND_TARGET=OFF" \

--- a/libs/webkit2gtk3/DETAILS
+++ b/libs/webkit2gtk3/DETAILS
@@ -1,11 +1,11 @@
           MODULE=webkit2gtk3
-         VERSION=2.32.0
+         VERSION=2.32.1
           SOURCE=webkitgtk-$VERSION.tar.xz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/webkitgtk-$VERSION
       SOURCE_URL=https://www.webkitgtk.org/releases
-      SOURCE_VFY=sha256:9d7df4dae9ada2394257565acc2a68ace9308c4c61c3fcc00111dc1f11076bf0
+      SOURCE_VFY=sha256:136117317f70f66486f71b8edf5e46f8776403c5d8a296e914b11a36ef836917
          ENTERED=20070919
-         UPDATED=20210327
+         UPDATED=20210606
            SHORT="A Gtk+ web rendering engine"
 
 cat << EOF


### PR DESCRIPTION
**IMPORTANT: v2.32.0 onwards will not compile with wpebackend support enabled, until our version of wpebackend-fdo is updated (PR for that is submitted)**

BUILD:
 - pointed the build to specifically use python3 ( defaults to python2 if it's installed )
 -_default cmake build_ works without problems
 - removed the WPEBACKEND query

 CONFIGURE:
- removed the WPEBACKEND query

DEPENDS:
- removed some redundant _depends_ that are installed by other _depends_
- removed the WPEBACKEND check, changed it to an _optional depends_

DETAILS: normal version bump changes