### PR TITLE
caribou : make gtk2 dependency optional

### DIFF
--- a/apps/caribou/DEPENDS
+++ b/apps/caribou/DEPENDS
@@ -12,3 +12,8 @@ optional_depends gobject-introspection \
                  "--disable-introspection" \
                  "for object introspection" \
                  "y"
+optional_depends gtk+-2 \
+  "" \
+  "--disable-gtk2-module" \
+  "for GTK+-2 support" \
+  "n"

--- a/apps/caribou/DETAILS
+++ b/apps/caribou/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:9c43d9f4bd30f4fea7f780d4e8b14f7589107c52e9cb6bd202bd0d1c2064de55
         WEB_SITE=http://live.gnome.org/Caribou/
          ENTERED=20130210
-         UPDATED=20190322
+         UPDATED=20220123
            SHORT="A text entry and UI navigation application for Gtk+-3"
 
 cat <<EOF


### PR DESCRIPTION
_caribou_ requires gtk2 to be explicitly disabled

 - updated DEPENDS to make gtk2 optional
 - change DETAILS to update modification date