### PR TITLE
gnome-desktop: fix depends

### DIFF
--- a/core/gnome-desktop/DEPENDS
+++ b/core/gnome-desktop/DEPENDS
@@ -3,21 +3,14 @@ depends iso-codes
 depends gsettings-desktop-schemas
 depends libxkbfile
 depends bubblewrap
-depends iso-codes
 depends libseccomp
 depends itstool
 depends libxml2
 depends xkeyboard-config
-depends meson
+depends gobject-introspection
 
 optional_depends gtk-doc \
-                 "-Dgtk-doc=true" \
-                 "-Dgtk-doc=false" \
+                 "-Dgtk_doc=true" \
+                 "-Dgtk_doc=false" \
                  "for building documentation" \
                  "n"
-
-optional_depends gobject-introspection \
-                 "-Dintrospection=true" \
-                 "-Dintrospection=false" \
-                 "for object introspection" \
-                 "y"


### PR DESCRIPTION
DEPENDS:
remove duplicate iso-codes entry
remove meson dep (installed by default)
add gobject-introspection dep (hard dep)

correct underscore vs dash on gtk-doc optional
remove unused gobject optional (hard dep)