### PR TITLE
NetworkManager: Fixing some more typos in DEPENDS. Adding unset LDFAG…

### DIFF
--- a/core/NetworkManager/BUILD
+++ b/core/NetworkManager/BUILD
@@ -1,3 +1,5 @@
+unset LDFLAGS &&
+
 OPTS+=" -D tests=no \
         -D qt=false \
         -D ebpf=false \

--- a/core/NetworkManager/DEPENDS
+++ b/core/NetworkManager/DEPENDS
@@ -8,6 +8,7 @@ depends %UDEV
 depends libgudev
 depends mobile-broadband-provider-info
 depends meson
+depends polkit
 
 optional_depends readline \
                  "-D nmcli=true" \
@@ -25,11 +26,6 @@ optional_depends gnutls "-D crypto=gnutls" "" "for TLS crypto support"
 optional_depends dhcpcd   "-D dhcpcd=yes"   "-D dhcpcd=no"   "for DHCP client"
 optional_depends dhcp     "-D dhclient=yes" "-D dhclient=no" "for standard DHCP client"
 optional_depends valgrind "-D valgrind=yes" "-D valgrind=no" "for valgrind support"
-
-optional_depends polkit \
-                 "-D polkit=true  -D polkit_agent=true" \
-                 "-D polkit=false -D polkit_agent=false" \
-                 "for polkit support"
 
 optional_depends iwd \
                  "-D iwd=true" \
@@ -54,7 +50,7 @@ optional_depends curl \
                  "n"
 
 optional_depends ModemManager \
-                 "-D modem-manager=true" \
+                 "-D modem_manager=true" \
                  "-D modem_manager=false" \
                  "for mobile broadband modem support" \
                  "n"
@@ -63,12 +59,6 @@ optional_depends libpsl \
                  "-D libpsl=true" \
                  "-D libpsl=false" \
                  "link against libpsl" \
-                 "n"
-
-optional_depends jansson \
-                 "-D json_validation=true  -D ovs=true" \
-                 "-D json_validation=false -D ovs=false" \
-                 "for JSON validation and Open vSwitch support" \
                  "n"
 
 optional_depends newt \

--- a/core/NetworkManager/DETAILS
+++ b/core/NetworkManager/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:faa389c9e9ca78243cfab4a8bed6db132f82e5b5e66bb9d44af93379d1348398
         WEB_SITE=http://gnome.org/projects/$MODULE
          ENTERED=20130216
-         UPDATED=20220304
+         UPDATED=20220305
            SHORT="Network Management daemon"
 
 cat << EOF


### PR DESCRIPTION
…S to BUILD avoiding this;

[724/729] Generating NetworkManager.ver with a custom command
FAILED: src/core/NetworkManager.ver
/usr/src/NetworkManager-1.32.2/tools/create-exports-NetworkManager.sh --called-from-build /usr/src/NetworkManager-1.32.2
nm: ./src/core/NetworkManager-all-sym: no symbols
nm: ./src/core/devices/adsl/libnm-device-plugin-adsl.so: no symbols
nm: ./src/core/devices/bluetooth/libnm-device-plugin-bluetooth.so: no symbols
nm: ./src/core/devices/ovs/libnm-device-plugin-ovs.so: no symbols
nm: ./src/core/devices/wifi/libnm-device-plugin-wifi.so: no symbols
nm: ./src/core/devices/wwan/libnm-device-plugin-wwan.so: no symbols
nm: ./src/core/devices/wwan/libnm-wwan.so: no symbols
[725/729] Generating org.freedesktop.NetworkManager.policy with a custom command
Generating and caching the translation database
Merging translations into data/org.freedesktop.NetworkManager.policy.
CREATED data/org.freedesktop.NetworkManager.policy
[726/729] Generating NM-1.0.gir with a custom command
g-ir-scanner: link: gcc -o /usr/src/NetworkManager-1.32.2/build/tmp-introspectjdn977gi/NM-1.0 -D_FORTIFY_SOURCE=2 -O2 -march=native -pipe /usr/src/NetworkManager-1.32.2/build/tmp-introspectjdn977gi/NM-1.0.o -L. -Wl,-rpath,. -Wl,--no-as-needed -L./src/libnm-client-impl -lnm -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lgmodule-2.0 -ludev -lgirepository-1.0 -lgio-2.0 -lgobject-2.0 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lglib-2.0 -s
ninja: build stopped: subcommand failed.
Creating /var/log/lunar/compile/NetworkManager-1.32.2.xz
! Problem detected during BUILD