### PR TITLE
eog: fix build with newer meson

### DIFF
--- a/apps/eog/PRE_BUILD
+++ b/apps/eog/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sedit "/  desktop,/d;/  appdata,/d" data/meson.build


### PR DESCRIPTION
I was getting this error:

```
data/meson.build:25:5: ERROR: Function does not take positional arguments.
```