### PR TITLE
gedit: fix build with newer meson

### DIFF
--- a/apps/gedit/BUILD
+++ b/apps/gedit/BUILD
@@ -1,1 +1,0 @@
-default_meson_build

--- a/apps/gedit/PRE_BUILD
+++ b/apps/gedit/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sedit "/  appdata,/d;/  desktop_file,/d" data/meson.build


### PR DESCRIPTION
I was getting this error, same thing as eog:

```
data/meson.build:6:20: ERROR: Function does not take positional arguments.
```