### PR TITLE
gdk-pixbuf: re-enable the xpm loader

### DIFF
--- a/libs/gdk-pixbuf/BUILD
+++ b/libs/gdk-pixbuf/BUILD
@@ -1,5 +1,7 @@
 rm -f /usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache &&
 
-OPTS+=" -Dinstalled_tests=false -Ddocs=false -Dintrospection=enabled"
+# others=enabled is for the xpm loader and few others, needed by gkrellm
+OPTS+=" -Dothers=enabled -Dinstalled_tests=false \
+ -Ddocs=false -Dintrospection=enabled"
 
 default_meson_build


### PR DESCRIPTION
When starting gkrellm I was getting this error:

Error loading XPM image loader: Image type "xpm" is not supported
Cannot load xpm: (null)
gkrellm segmentation fault: (?)

According to https://github.com/Homebrew/homebrew-core/issues/169803 the loader can be re-enabled with "-Dothers=enabled", making gkrellm work again.