### PR TITLE
gobject-introspection: remove misleading message in DEPENDS

### DIFF
--- a/core/gobject-introspection/DEPENDS
+++ b/core/gobject-introspection/DEPENDS
@@ -7,5 +7,5 @@ depends meson
 optional_depends cairo \
                  "-D cairo=enabled" \
                  "-D cairo=disabled" \
-                 "for cairo graphics support${PROBLEM_COLOR} While this defaults to yes, you should say no on a clean install, else you will have troubles${DEFAULT_COLOR}" \
+                 "for cairo graphics support (recommended)" \
                  "y"


### PR DESCRIPTION
According to the comment in DEPENDS:

```
# actually this is an optdep, but most introspection modules
# will fail without cairo support
```

enabling cairo is recommended now, no troubles in sight currently.