### PR TITLE
bubblewrap: Version bumped to 0.11.2

### DIFF
--- a/libs/bubblewrap/DETAILS
+++ b/libs/bubblewrap/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=bubblewrap
-         VERSION=0.11.0
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://github.com/projectatomic/bubblewrap/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:988fd6b232dafa04b8b8198723efeaccdb3c6aa9c1c7936219d5791a8b7a8646
-        WEB_SITE=https://github.com/projectatomic/bubblewrap/
-         ENTERED=20190910
-         UPDATED=20241030
-           SHORT="Unprivileged sandboxing tool"
+    MODULE=bubblewrap
+   VERSION=0.11.2
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://github.com/projectatomic/bubblewrap/releases/download/v$VERSION/
+SOURCE_VFY=sha256:69abc30005d2186baf7737feacd8da35633b93cf5af38838ecff17c5f8e924f6
+  WEB_SITE=https://github.com/projectatomic/bubblewrap/
+   ENTERED=20190910
+   UPDATED=20260425
+     SHORT="Unprivileged sandboxing tool"
 
 cat << EOF
 Bubblewrap could be viewed as setuid implementation of a subset of user


### PR DESCRIPTION
Upgrade bubblewrap from 0.11.0 to 0.11.2

- Version: 0.11.0 → 0.11.2
- Source: Updated to official release archive
- SHA256: 69abc30005d2186baf7737feacd8da35633b93cf5af38838ecff17c5f8e924f6
- Updated: 20260425

---
*Automated PR created by n8n + Claude AI*